### PR TITLE
Fix: iconButton svg 적용 되도록 변경

### DIFF
--- a/src/components/common/IconButton/IconButton.module.scss
+++ b/src/components/common/IconButton/IconButton.module.scss
@@ -1,14 +1,10 @@
-.icon {
-  border-radius: 100%;
-  cursor: pointer;
-  overflow: hidden;
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+.iconContainer {
+  position: relative;
+  .icon {
+    border-radius: 100%;
+    cursor: pointer;
+    overflow: hidden;
   }
-
   &[data-size='xsmall'] {
     width: 16px;
     height: 16px;

--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -17,13 +17,12 @@ export default function IconButton({
   size,
 }: IIconButtonProps) {
   return (
-    <>
+    <div data-size={size} className={styles.iconContainer}>
       <div
-        data-size={size}
         className={`${styles.icon} ${className}`}
         onClick={clickIconButtonHandler}>
-        <Image alt="icon" src={imgUrl} width={0} height={0} sizes="100vw" />
+        <Image alt="icon" src={imgUrl} fill />
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ✨ 과제 내용

as-is : next/Image tag 에 Img를 넣었을때만 고려해서, svg 파일에도 사이즈 적용이 안됬음.
to-be : 부모태그에 사이즈를 주고, Image tag에 fill 속성을 주어 부모태그의 사이즈에 맞춰지도록 변경하였습니다.

사이즈 props : xsmall , small, medium. large 

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
